### PR TITLE
Scientific notation support for onMath

### DIFF
--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -39,7 +39,7 @@ function MathScopeEval(str) {
 }
 
 function constructMathRe() {
-  var re = new RegExp("^([\\d\\s" + REEscape(mathSymbols) + "]|(" + mathKeys.join(")|(") + "))+$");
+  var re = new RegExp("^((?:\\d*(?:\\.\\d+)?(e\\d+)?)|[\\s" + REEscape(mathSymbols) + "]|(" + mathKeys.join(")|(") + "))+$");
   return re;
 }
 


### PR DESCRIPTION
The number regex now consumes entire numbers at once, including ones using scientific notation (e.g. 3e12) which were previously not recognized.

![screenshot 2014-06-24 at 5 34 46 pm](https://cloud.githubusercontent.com/assets/990370/3378223/737b6e98-fbe7-11e3-9386-38dec127777e.png)
