### PR TITLE
Fixed crash on commit url bug in github module

### DIFF
--- a/modules/github/index.js
+++ b/modules/github/index.js
@@ -330,6 +330,7 @@ var blacklistedPaths = [
     '/features',
     '/plans',
     '/privacy',
+    '/search',
     '/security',
     '/showcases',
     '/stars',
@@ -422,8 +423,13 @@ var githubURLRegexes = [
                 if (err) {
                     cb("Github response is dicked");
                 } else {
-                    var committer = res.committer.login,
+                    var committer = res.committer,
                         message = res.commit.message;
+                    if (committer == null) {
+                        committer = res.committer.name;
+                    } else {
+                        committer = res.committer.login;
+                    }
                     // Extract first line of commit message
                     message = /.*/.exec(message);
                     if (message) message = message[0];


### PR DESCRIPTION
Commits where users were not github users would cause crashes sometimes. Fixed it.

In addition, the bot would mistake github.com/search/ URLS as belonging to the user 'search.' It's now been blacklisted.
