### PR TITLE
Only reply if the regex matched something.

### DIFF
--- a/modules/regex/index.js
+++ b/modules/regex/index.js
@@ -15,9 +15,11 @@ module.exports.msg =  function(text, from, reply, raw) {
                 replace = match[2];
             var fixed = replaceAll(find, replace, personLastSaid);
 
-            var response = "<" + from + "> " + fixed;
+						if (fixed != personLastSaid) {
+							var response = "<" + from + "> " + fixed;
 
-            reply(response);
+							reply(response);
+						}
         }
     } else {
         // The proper way to do this would be with scrollback module but w/e


### PR DESCRIPTION
This allows people to use regexes that refer to things other people say without spamming the channel. 

An alternative method for acheiving this would be to have the regex work on the last thing said. 
If we did this, it would probably be a good idea to provide a syntax for specifying a line to regex, perhaps with a number or an additional match regex.
However, that would require this module to be not-shitty, which seems to go against its design philosophy.
