### PR TITLE
Only get the title of the first argument to !title

### DIFF
--- a/modules/title/index.js
+++ b/modules/title/index.js
@@ -20,7 +20,7 @@ function getSelector(url, selector, reply) {
 }
 
 module.exports.run_title = function(remainder, p, reply) {
-  getSelector(remainder, 'title', reply);
+  getSelector(p[0], 'title', reply);
 };
 module.exports.run_websel = function(r, p, reply) {
   getSelector(p[1], p[0], reply);


### PR DESCRIPTION
`!title` fails, for instance, if you do something like `!title http://example.com/index.html HELLO DONGS`. This fixes that.