### PR TITLE
Catch a missing youtube config

### DIFF
--- a/modules/youtube/index.js
+++ b/modules/youtube/index.js
@@ -7,7 +7,9 @@ var moment = require('moment');
 var apiKey = "";
 module.exports.init = function(b) {
 	b.getConfig("google.json", function(err, conf) {
-		apiKey = conf.apiKey
+		if(!err) {
+			apiKey = conf.apiKey
+		}
 	});
 };
 


### PR DESCRIPTION
I really didn't think about whether or not we should actually do something if the config isn't there, but this at least lets the bot start without crashing.