### PR TITLE
More filters, reckless-irc-exec-style char limit, and persistent scope

### DIFF
--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -61,12 +61,20 @@ module.exports.msg = function(text, from, reply, raw) {
 
   var res = MathScopeEval(text);
 
-  // If res is null or just echos our input, filter it
-  if(res === null || res == text) {
+  if(res == null) {
     return;
   }
 
   res = res.toString();
+
+  var resclean = res.replace(/\s/g, '');
+  var textclean = text.replace(/\s/g, '');
+
+  // If res parrots our input, filter it
+  if( res == text || resclean == text || res == textclean 
+      || resclean == textclean ) {
+    return;
+  }
 
   // If the response is javascript
   if(javascript.test(res)) {

--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -1,10 +1,10 @@
 var mathjs = require('mathjs');
+var mathParser = mathjs.parser();
 var RC = require('regex-chain');
 
 function MathScopeEval(str) {
   try {
-    var result = mathjs.eval(str);
-    return mathjs.eval(str);
+    return mathParser.eval(str);
   } catch(ex) {
     return null;
   }

--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -30,7 +30,7 @@ var mathSymbols = ".,*+-/()%=";
 var onlySymbols = new RC("^[\\s" + REEscape(mathSymbols) + "]*$");
 var onlyNumbers = new RC(/^[\.\s\d]*$/);
 var onlyKeys = new RC("^\\s*((" + mathKeys.join(")|(") + "))+\\s*$");
-var onlyTime = new RC(/^\s*([0-9]+:?)+\s*$/);
+var onlyTime = new RC(/^\s*(:?[0-9]+:?)+\s*$/);
 var onlyQuote = new RC(/^".+"$/);
 var funnyFractions = new RC(/^\s*(([0-9][0]?|11)\s*\/\s*(10|5|100))\s*$/);
 var plusN = new RC(/^\s*\++\d+\s*$/);
@@ -45,6 +45,11 @@ module.exports.msg = function(text, from, reply, raw) {
   }
 
   var res = MathScopeEval(text);
+
+  // If res just echos our input, filter it
+  if(res == text) {
+    return;
+  }
 
   if(res !== null) {
     reply(res);

--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -55,3 +55,12 @@ module.exports.msg = function(text, from, reply, raw) {
     reply(res);
   }
 };
+
+module.exports.command = "reset";
+
+module.exports.run = function(remainder, parts, reply, command, from, to, text, raw) {
+  // Create a new scope
+  mathParser = mathjs.parser();
+  reply("Parser reinitialized");
+};
+

--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -24,6 +24,9 @@ for(var i=0;i<mathKeysToGet.length;i++) {
   mathItems[mathKeysToGet[i]] = mathjs[mathKeysToGet[i]];
 }
 
+//
+// INPUT FULTERS
+// 
 var mathKeys = Object.keys(mathItems);
 var mathSymbols = ".,*+-/()%=";
 
@@ -38,6 +41,11 @@ var plusN = new RC(/^\s*\++\d+\s*$/);
 var ignoreRe = onlySymbols.or(onlyNumbers).or(funnyFractions).or(onlyKeys).or(plusN)
                .or(onlyQuote).or(onlyTime);
 
+//
+// OUTPUT FILTERS
+//
+var javascript = new RC("function|{|}|return|arguments|length"); // This is by no means "good"
+
 
 module.exports.msg = function(text, from, reply, raw) {
   if(ignoreRe.test(text)) {
@@ -48,6 +56,11 @@ module.exports.msg = function(text, from, reply, raw) {
 
   // If res just echos our input, filter it
   if(res == text) {
+    return;
+  }
+
+  // If the response is javascript
+  if(javascript.test(res)) {
     return;
   }
 

--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -83,7 +83,7 @@ module.exports.msg = function(text, from, reply, raw) {
 
 module.exports.command = "reset";
 
-module.exports.run = function(remainder, parts, reply) {
+module.exports.run_reset = function(remainder, parts, reply) {
   // Create a new scope
   mathParser = mathjs.parser();
   reply("Parser reinitialized");

--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -34,11 +34,11 @@ var mathSymbols = ".,*+-/()%=";
 
 var onlySymbols = new RC("^[\\s" + REEscape(mathSymbols) + "]*$");
 var onlyNumbers = new RC(/^[\.\s\d]*$/);
-var onlyKeys = new RC("^\\s*((" + mathKeys.join(")|(") + "))+\\s*$");
-var onlyTime = new RC(/^\s*(:?[0-9]+:?)+\s*$/);
+var onlyKeys = new RC("^((" + mathKeys.join(")|(") + "))+$");
+var onlyTime = new RC(/^(:?[0-9]+:?)+$/);
 var onlyQuote = new RC(/^".+"$/);
-var funnyFractions = new RC(/^\s*(([0-9][0]?|11)\s*\/\s*(10|5|100))\s*$/);
-var plusN = new RC(/^\s*\++\d+\s*$/);
+var funnyFractions = new RC(/^(([0-9][0]?|11)\s*\/\s*(10|5|100))$/);
+var plusN = new RC(/^\++\d+$/);
 
 var ignoreRe = onlySymbols.or(onlyNumbers).or(funnyFractions).or(onlyKeys).or(plusN)
                .or(onlyQuote).or(onlyTime);
@@ -53,6 +53,8 @@ module.exports.init = function(b) {
 }
 
 module.exports.msg = function(text, from, reply, raw) {
+  text = text.trim();
+
   if(ignoreRe.test(text)) {
     return;
   }


### PR DESCRIPTION
I've added more filters, one for accepting lists (no longer allows ":50" alone), one for outputting "javascript" (which it disallows), and a general filter which disallows echoing what was input (if you just type "hm" it won't parrot it back).

If output runs over 400 characters, it truncates it and prints it out in the channel it's ran in. It sends the rest of the output to the caller.

Scope is now persistent too. If you define a function f(x) you can call it again later. I added !reset which resets the parser, so that when someone defines sin(x) to always be 0 you can reset the behavior.