### PR TITLE
Add ezquo module

### DIFF
--- a/modules/que/index.js
+++ b/modules/que/index.js
@@ -1,0 +1,55 @@
+
+var bot = null;
+
+module.exports.init = function(b) {
+  bot = b;
+};
+
+module.exports.commands = ['que'];
+
+module.exports.run = function(r, parts, reply, command, from, to) {
+  if (!bot.isChannel(to))
+    return;
+
+  var scrollbackModule = bot.modules['sirc-scrollback'];
+  if (!scrollbackModule)
+    return console.log("No scrollback, can't ezquo");
+
+  var specs = scrollbackModule.parseSpecs(r);
+
+  scrollbackModule.getScrollbackForSpecs(to, specs, function(err, lines) {
+    if (err)
+      return bot.sayTo(from, err);
+
+    var spec = null;
+    for(var i=0; i < lines.length; i++) {
+      var line = lines[i];
+
+      if (line.spec !== spec) {
+        spec = line.spec;
+        var res = "";
+        if(spec.nicks.length > 0) {
+          res += spec.nicks.join(", ");
+          res += " ";
+        }
+        if(spec.regexes.length > 0) {
+          res += spec.regexes.map(function(regex) { return regex.toString(); }).join(", ");
+          res += " ";
+        }
+        res += spec.lines.join(", ");
+        res += ":";
+        bot.sayTo(from, res);
+      }
+
+      var res = "(" + line.line + ") ";
+
+      formattedLine = scrollbackModule.formatLine(line.content);
+      if (formattedLine.match(/(pls|#)noquo/))
+        res += "[noquo'd]";
+      else
+        res += formattedLine;
+
+      bot.sayTo(from, res);
+    }
+  });
+};

--- a/modules/que/package.json
+++ b/modules/que/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "que",
+  "version": "0.0.1",
+  "description": "What'd they say?",
+  "main": "index.js",
+  "dependencies": {
+  },
+  "author": "drusepth",
+  "license": "MIT"
+}


### PR DESCRIPTION
Probably good to note: this module doesn't work. Scrollback searching isn't getting the correct lines.

Intent: this module allows you to specify a nick and a search limit (e.g. `ek 5`) and it'll split out the last 5 lines that person has said, already reverse-indexed to assist in out-of-context !quo's.

Example use:
```
01:18 < drusepth> !ezquo drusepth 3
01:18 < ^> (3) <drusepth> I'm so great
01:18 < ^> (2) <drusepth> I built this broken feature
01:18 < ^> (1) <drusepth> Okay time to sleep
```

Would be nice if it could also support regex/keyword searches, so you can quickly find the offset of the last N times @hfukada talked about kpop.

e.g.
```
01:18 < drusepth> !ezquo suroi 2 /kpop/
01:18 < ^> (98) <suroi> kpop is the bomb diggity
01:18 < ^> (32) <suroi> this is a real quote about kpop
```

Does not re-print-out #noquo lines.

Assigning to @LinuxMercedes because wtf is this scrollback code. :ship: 