### PR TITLE
onMath: filter out "i'm g"

### DIFF
--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -26,6 +26,9 @@ for(var i=0;i<mathKeysToGet.length;i++) {
   mathItems[mathKeysToGet[i]] = mathjs[mathKeysToGet[i]];
 }
 
+// Strings to not match; case insensitive fyi
+var ignoreStrings = ["i'm g"];
+
 //
 // INPUT FULTERS
 //
@@ -51,6 +54,10 @@ var javascript = new RC("function|{|}|return|arguments|length"); // This is by n
 
 module.exports.init = function(b) {
   bot = b;
+};
+
+function justAddsParens(before, after) {
+  return before.toLowerCase().replace(/\(|\)/g, '') === after.toLowerCase().replace(/\(|\)/g, '');
 }
 
 module.exports.msg = function(text, from, reply, raw) {
@@ -60,9 +67,13 @@ module.exports.msg = function(text, from, reply, raw) {
     return;
   }
 
+  if(ignoreStrings.indexOf(text) !== -1) {
+    return;
+  }
+
   var res = MathScopeEval(text);
 
-  if(res == null) {
+  if(res === null) {
     return;
   }
 
@@ -72,8 +83,11 @@ module.exports.msg = function(text, from, reply, raw) {
   var textclean = text.replace(/\s/g, '');
 
   // If res parrots our input, filter it
-  if( res == text || resclean == text || res == textclean 
-      || resclean == textclean ) {
+  if(res == text ||
+     resclean == text ||
+     res == textclean ||
+     resclean == textclean ||
+     justAddsParens(resclean, textclean)) {
     return;
   }
 

--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -57,7 +57,7 @@ module.exports.init = function(b) {
 };
 
 function justAddsParens(before, after) {
-  return before.toLowerCase().replace(/\(|\)/g, '') === after.toLowerCase().replace(/\(|\)/g, '');
+  return before.toLowerCase().replace(/[()]/g, '') === after.toLowerCase().replace(/[()]/g, '');
 }
 
 module.exports.msg = function(text, from, reply, raw) {

--- a/modules/onMath/onmath.test.js
+++ b/modules/onMath/onmath.test.js
@@ -11,7 +11,7 @@ function assertResponse(input, output, done) {
 
 function assertNoResponse(input, done) {
   onmath.msg(input, "#test", function(reply) {
-    assert.fail("did not expect response to this");
+    assert.fail(reply, "", "Should not have responded");
   }, "ignored raw");
 
   process.nextTick(done);
@@ -24,7 +24,7 @@ describe('onMath', function() {
       ["1*1", "1"],
     ];
 
-    async.every([["1 + 1", "2"], ["1 * 1", "1"]], function(el, callback) {
+    async.every(simpleMath, function(el, callback) {
       assertResponse(el[0], el[1], function() {
         callback(true);
       });
@@ -41,7 +41,9 @@ describe('onMath', function() {
       "i'm g",
       "9/10",
       "10/10",
+      "11/10",
       "10/100",
+      "(1)",
       // "W 0 B S C A L E", // One can dream
     ];
 

--- a/modules/onMath/onmath.test.js
+++ b/modules/onMath/onmath.test.js
@@ -1,0 +1,68 @@
+var onmath = require('.');
+var assert = require('chai').assert;
+var async = require('async');
+
+function assertResponse(input, output, done) {
+  onmath.msg(input, "#test", function(reply) {
+    assert.equal(reply, output);
+    done();
+  }, "ignored raw");
+}
+
+function assertNoResponse(input, done) {
+  onmath.msg(input, "#test", function(reply) {
+    assert.fail("did not expect response to this");
+  }, "ignored raw");
+
+  process.nextTick(done);
+}
+
+describe('onMath', function() {
+  it('should do simple math', function(done) {
+    var simpleMath = [
+      ["1+1", "2"],
+      ["1*1", "1"],
+    ];
+
+    async.every([["1 + 1", "2"], ["1 * 1", "1"]], function(el, callback) {
+      assertResponse(el[0], el[1], function() {
+        callback(true);
+      });
+    }, function(err) {
+      assert.isOk(err);
+      done();
+    });
+  });
+  it("should ignore dumb stuff", function(done) {
+    var dumbStuff = [
+      "1",
+      "e",
+      "E",
+      "i'm g",
+      "9/10",
+      "10/10",
+      "10/100",
+      // "W 0 B S C A L E", // One can dream
+    ];
+
+    async.every(dumbStuff, function(el, callback) {
+      assertNoResponse(el, function() { callback(true); });
+    }, function(err) {
+      assert.isOk(err);
+      done();
+    });
+  });
+
+  it("should allow clearing", function(done) {
+    assertResponse("x=10", "10", function() {
+      assertResponse("x * 100", "1000", function() {
+        onmath.run_reset("", null, function() {
+          assertNoResponse("x * 100", function() {
+            // TODO this indentation
+            done();
+          });
+        });
+      });
+    });
+  });
+});

--- a/package.json
+++ b/package.json
@@ -10,10 +10,14 @@
     "snailescape.js": "^2.0.1",
     "underscore": "latest"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "mocha": "^2.5.3"
+  },
   "scripts": {
     "start": "node bot.js",
-    "install": "./installModules.sh"
+    "install": "./installModules.sh",
+    "test": "mocha $(git ls-files | grep -E \"test.js$\")"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Prior to this, "i'm g" -> "(i) m g".

After this change, "i'm g" no longer expands.

I also added a bunch of tests because frankly this is ridiculous.

r? @LinuxMercedes @hfukada @drusepth 