### PR TITLE
Switch back to a standard node-irc release

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "async": "latest",
     "change-case": "^2.3.0",
-    "irc": "git+https://github.com/LinuxMercedes/node-irc.git#bleeding",
+    "irc": "^0.5.1",
     "snailescape.js": "^2.0.1",
     "underscore": "latest"
   },


### PR DESCRIPTION
Node-irc finally has upstreamed all our bug fixes, so there's no point in not tracking it (for now, anyways).