### PR TITLE
Set a user for npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM node:6
+FROM node:7
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
-RUN npm install
 
+RUN useradd --home-dir /usr/src/app bot
+RUN chown -R bot:bot /usr/src/app
 VOLUME /usr/src/app/conf
 VOLUME /usr/src/app/data
+
+USER bot
+RUN npm install
 
 CMD ["node", "--max_old_space_size=150", "bot.js"]


### PR DESCRIPTION
This is required nowadays because at some point npm decided root users
shouldn't be allowed to run install scripts.

See also https://github.com/npm/npm/issues/3497