### PR TITLE
Revert "Switch to un-broken urban module"

### DIFF
--- a/modules/urbandictionary/package.json
+++ b/modules/urbandictionary/package.json
@@ -4,7 +4,7 @@
   "description": "UrbanDictionary module",
   "main": "index.js",
   "dependencies": {
-    "urban": "git+https://github.com/LinuxMercedes/urban.git"
+    "urban": "latest"
   },
   "author": "LinuxMercedes",
   "license": "MIT"


### PR DESCRIPTION
The urban module has been updated with our patches and some new bugfixes
(https://github.com/mvrilo/urban/pull/6 in particular), so there's no
need to maintain a separate fork of it now.

This reverts commit 3bcb3132946da5d9f96af5f08bb3286f37a1d2ba.