### PR TITLE
Switch to CoinMarketCap API since BTC-E is in jail

### DIFF
--- a/modules/btc/index.js
+++ b/modules/btc/index.js
@@ -1,4 +1,4 @@
-var coinmarketcap = require('coinmarketcap');
+var coinmarketcap = require('@linuxmercedes/coinmarketcap');
 var _ = require('lodash');
 
 function findDataForCoin(coin, data) {

--- a/modules/btc/index.js
+++ b/modules/btc/index.js
@@ -31,7 +31,7 @@ function findDataForCoin(coin, data) {
 function getTickerData(coin, callback) {
   coinmarketcap.ticker()
     .then(data => callback(findDataForCoin(coin,data)))
-    .catch(reason => {console.log(reason); return callback("Error occured getting price")});
+    .catch(reason => {this.log.debug(reason); return callback("Error occured getting price")});
 }
 
 module.exports.commands = ['btc', 'ltc', 'doge', 'eth', 'etc', 'zec'];

--- a/modules/btc/index.js
+++ b/modules/btc/index.js
@@ -1,53 +1,43 @@
-var BTCE = require('btce');
-var btce = new BTCE();
-var http = require('http');
+var coinmarketcap = require('coinmarketcap');
+var _ = require('lodash');
 
-function capitalize(str) {
-  if(str === '') return '';
-  return str[0].toUpperCase() + str.slice(1);
-}
-
-function getDogecoinData(callback) {
-  http.get('http://pubapi.cryptsy.com/api.php?method=singlemarketdata&marketid=132', function(res) {
-    var j = '';
-    res.on('data', function(c) { j += c; });
-    res.on('end', function() {
-      try {
-        j = JSON.parse(j.toString());
-        var dgc_to_btc_last = j.return.markets.DOGE.lasttradeprice;
-        var dgc_to_btc_avg = j.return.markets.DOGE.recenttrades.map(function(l) { return parseFloat(l.price); });
-        dgc_to_btc_avg = dgc_to_btc_avg.reduce(function(l,r){return l+r;}) / dgc_to_btc_avg.length;
-        btce.ticker({pair: "btc_usd"}, function(err, data) {
-          if(err || !data || !data.ticker) return callback("Error occured getting BTC prices");
-          data = data.ticker;
-          callback("Last: $" + data.last * dgc_to_btc_last + " | Avg: $" + data.avg * dgc_to_btc_avg);
-        });
-      } catch(ex) {
-        callback(ex);
-        callback("Could not get doge");
-      }
-    });
-  });
-}
-
-function getTickerData(coin, metric, callback) {
-  if(coin === 'dgc') {
-    return getDogecoinData(callback);
+function findDataForCoin(coin, data) {
+  let matches = _.filter(data, datum => coin.toLowerCase() === datum.symbol.toLowerCase());
+  if (matches.length == 0) {
+    return "Could not find data for " + coin;
   }
-  btce.ticker({pair: coin+"_usd"}, function(err, data) {
-    if(err || !data || !data.ticker) return callback("Error occured getting BTC prices");
-    data = data.ticker;
-    if(data[metric.toLowerCase()]) {
-      callback(capitalize(metric) + ": $" + data[metric.toLowerCase()]);
-    } else {
-      callback("Last: $" + data.last + " | Avg: $" + data.avg);
-    }
-  });
+
+  let match = matches[0];
+
+  let price = "Price: $" + match.price_usd
+  let change = " | Change over last:"
+  let append_change = false;
+
+  if(match.percent_change_1h !== null) {
+    change += (" Hour: " + match.percent_change_1h + "%");
+    append_change = true;
+  }
+  if(match.percent_change_24h !== null) {
+    change += (" Day: " + match.percent_change_24h + "%");
+    append_change = true;
+  }
+  if(match.percent_change_7d !== null) {
+    change += (" Week: " + match.percent_change_7d + "%");
+    append_change = true;
+  }
+
+  return price + (append_change ? change : "");
 }
 
-module.exports.commands = ['btc', 'ltc', 'dgc', 'eth'];
+function getTickerData(coin, callback) {
+  coinmarketcap.ticker()
+    .then(data => callback(findDataForCoin(coin,data)))
+    .catch(reason => {console.log(reason); return callback("Error occured getting price")});
+}
+
+module.exports.commands = ['btc', 'ltc', 'doge', 'eth', 'etc', 'zec'];
 module.exports.run = function(remainder, parts, reply, command, from, to, text, raw) {
-  getTickerData(command, remainder, reply);
+  getTickerData(command, reply);
 };
 
 module.exports.run_cryptoval = function(remainder, parts, reply, command, from, to, text, raw) {

--- a/modules/btc/index.js
+++ b/modules/btc/index.js
@@ -31,7 +31,10 @@ function findDataForCoin(coin, data) {
 function getTickerData(coin, callback) {
   coinmarketcap.ticker()
     .then(data => callback(findDataForCoin(coin,data)))
-    .catch(reason => {this.log.debug(reason); return callback("Error occured getting price")});
+    .catch(reason => {
+      this.log.debug(reason);
+      return callback("Error occured getting price")
+    });
 }
 
 module.exports.commands = ['btc', 'ltc', 'doge', 'eth', 'etc', 'zec'];

--- a/modules/btc/index.js
+++ b/modules/btc/index.js
@@ -8,8 +8,8 @@ function findDataForCoin(coin, data) {
 
   let match = matches[0];
 
-  let price = "Price: $" + match.price_usd
-  let change = " | Change over last:"
+  let price = "Price: $" + match.price_usd;
+  let change = " | Change over last:";
   let append_change = false;
 
   if(match.percent_change_1h !== null) {
@@ -33,7 +33,7 @@ function getTickerData(coin, callback) {
     .then(data => callback(findDataForCoin(coin,data)))
     .catch(reason => {
       this.log.debug(reason);
-      return callback("Error occured getting price")
+      return callback("Error occured getting price");
     });
 }
 

--- a/modules/btc/index.js
+++ b/modules/btc/index.js
@@ -1,8 +1,7 @@
 var coinmarketcap = require('@linuxmercedes/coinmarketcap');
-var _ = require('lodash');
 
 function findDataForCoin(coin, data) {
-  let matches = _.filter(data, datum => coin.toLowerCase() === datum.symbol.toLowerCase());
+  let matches = data.filter(datum => coin.toLowerCase() === datum.symbol.toLowerCase());
   if (matches.length == 0) {
     return "Could not find data for " + coin;
   }

--- a/modules/btc/package.json
+++ b/modules/btc/package.json
@@ -4,7 +4,8 @@
   "description": "Bitcoin module",
   "main": "index.js",
   "dependencies": {
-    "btce": "latest"
+    "coinmarketcap": "https://github.com/LinuxMercedes/coinmarketcap.git#deps",
+    "lodash": "latest"
   },
   "author": "EuanK",
   "license": "MIT"

--- a/modules/btc/package.json
+++ b/modules/btc/package.json
@@ -4,7 +4,7 @@
   "description": "Bitcoin module",
   "main": "index.js",
   "dependencies": {
-    "coinmarketcap": "https://github.com/LinuxMercedes/coinmarketcap.git#deps",
+    "@linuxmercedes/coinmarketcap": "latest",
     "lodash": "latest"
   },
   "author": "EuanK",

--- a/modules/btc/package.json
+++ b/modules/btc/package.json
@@ -4,8 +4,7 @@
   "description": "Bitcoin module",
   "main": "index.js",
   "dependencies": {
-    "@linuxmercedes/coinmarketcap": "latest",
-    "lodash": "latest"
+    "@linuxmercedes/coinmarketcap": "latest"
   },
   "author": "EuanK",
   "license": "MIT"

--- a/modules/btc/yarn.lock
+++ b/modules/btc/yarn.lock
@@ -2,6 +2,33 @@
 # yarn lockfile v1
 
 
-btce@latest:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/btce/-/btce-0.4.4.tgz#6ba459767fb86822d31c0c90d9a60a834c871afa"
+"coinmarketcap@https://github.com/LinuxMercedes/coinmarketcap.git#deps":
+  version "0.2.0"
+  resolved "https://github.com/LinuxMercedes/coinmarketcap.git#f0ad32d02022d12dd5b8c876f836fa3d1128afd5"
+  dependencies:
+    node-fetch "^1.6.3"
+
+encoding@^0.1.11:
+  version "0.1.12"
+  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
+  dependencies:
+    iconv-lite "~0.4.13"
+
+iconv-lite@~0.4.13:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.18.tgz#23d8656b16aae6742ac29732ea8f0336a4789cf2"
+
+is-stream@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+lodash@latest:
+  version "4.17.4"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
+
+node-fetch@^1.6.3:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"
+  dependencies:
+    encoding "^0.1.11"
+    is-stream "^1.0.1"

--- a/modules/btc/yarn.lock
+++ b/modules/btc/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"coinmarketcap@https://github.com/LinuxMercedes/coinmarketcap.git#deps":
-  version "0.2.0"
-  resolved "https://github.com/LinuxMercedes/coinmarketcap.git#f0ad32d02022d12dd5b8c876f836fa3d1128afd5"
+"@linuxmercedes/coinmarketcap@latest":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@linuxmercedes/coinmarketcap/-/coinmarketcap-0.2.1.tgz#7876577e3c13db088557e12a4d2a4d2b07342bbd"
   dependencies:
     node-fetch "^1.6.3"
 

--- a/modules/btc/yarn.lock
+++ b/modules/btc/yarn.lock
@@ -22,10 +22,6 @@ is-stream@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
 
-lodash@latest:
-  version "4.17.4"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
-
 node-fetch@^1.6.3:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.1.tgz#899cb3d0a3c92f952c47f1b876f4c8aeabd400d5"


### PR DESCRIPTION
Oh, Bitcoin.

This also eliminates the separate means for fetching DogeCoin.

Right now the npm coinmarketcap package is broken (oh, node ecosystem) so we're depending on a patched version until the patches head upstream.

EDIT: patches are not heading upstream, so now we have a proper alternative package with our patches.