### PR TITLE
onMath: fix possible crash

### DIFF
--- a/modules/onMath/index.js
+++ b/modules/onMath/index.js
@@ -90,7 +90,11 @@ module.exports.msg = function(text, from, reply, raw) {
     return;
   }
 
-  res = res.toString();
+  if(res.toString) {
+    res = res.toString();
+  } else {
+    return;
+  }
 
   var resclean = res.replace(/\s/g, '');
   var textclean = text.replace(/\s/g, '');


### PR DESCRIPTION
`res` doesn't necessarily have a toString method. Ignore things that
don't.

cc @LinuxMercedes, I think we hit this crash in prod, but I can't remember the exact thing that triggered it.