### PR TITLE
Refactor Weather module to use Lat/Lng instead of City for WUnderground query

### DIFF
--- a/conf/weather.example.json
+++ b/conf/weather.example.json
@@ -1,4 +1,3 @@
 {
-  "wunderground_key": "...",
-  "google_key": "..."
+  "wunderground_key": "..."
 }

--- a/modules/weather/package.json
+++ b/modules/weather/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.0",
   "description": "Weather Underground module",
   "main": "index.js",
-  "dependencies": {},
+  "dependencies": {
+    "googlemaps": "~0.1.9"
+  },
   "author": "gmackie",
   "license": "MIT"
 }

--- a/modules/weather/yarn.lock
+++ b/modules/weather/yarn.lock
@@ -2,3 +2,17 @@
 # yarn lockfile v1
 
 
+googlemaps@~0.1.9:
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/googlemaps/-/googlemaps-0.1.20.tgz#80e1c44dad8ad622e33a4523520c1368e1d2ce14"
+  dependencies:
+    request "~2.2.9"
+    waitress ">=0.0.2"
+
+request@~2.2.9:
+  version "2.2.9"
+  resolved "https://registry.yarnpkg.com/request/-/request-2.2.9.tgz#efbf8afbfe7f1e200d483b99752b6c42b404a0f1"
+
+waitress@>=0.0.2:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/waitress/-/waitress-0.1.5.tgz#ed9b2a237cccd83cd735472f44f6c47b7e653af6"


### PR DESCRIPTION
Changed weather module to use the [googlemaps](https://github.com/moshen/node-googlemaps) package (currently used by `!geo`). Also changed the query in WUnderground API to use Lat/Lng from the Google response instead of trying to suss out the City/State/Country.

Also did some cleaning up of the syntax of the reply strings.

With manual testing, it looks like everything that was working before with `!w` and `!forecast` still work.

### Bonus:
```
2017-10-01 13:59:34	gmackie	!w sf
2017-10-01 13:59:34	suebot	San Francisco, CA | 73.3°F (feels like 73.3°F), Partly Cloudy | Humidity: 43%
```