### PR TITLE
modules/amazon: apply some pokemon error handling

### DIFF
--- a/modules/amazon/index.js
+++ b/modules/amazon/index.js
@@ -8,7 +8,7 @@ module.exports.init = function (bot) {
   bot.getConfig('amazon.json', (err, conf) => {
     if (err) return log.error(`Unable to load amazon module: ${err}`);
     try {
-      amazonClient = new amazon.createClient(conf);
+      amazonClient = amazon.createClient(conf);
     } catch (ex) {
       log.error(`Error loading amazon library: ${ex}`);
     }
@@ -24,11 +24,15 @@ const extractAsin = function (url) {
 };
 
 const generateErrorMessage = function (error) {
-  const err = error[0].Error[0];
-  let msg;
-  // AWS.InvalidParameterValue is returned when an prospective ASIN isn't actually a real ASIN, so we squash it
-  if (err.Code[0] != 'AWS.InvalidParameterValue') { msg = `Error: ${err.Message[0]}`; }
-  return msg;
+  try {
+    const err = error[0].Error[0];
+    // AWS.InvalidParameterValue is returned when an prospective ASIN isn't actually a real ASIN, so we squash it
+    if (err.Code[0] == 'AWS.InvalidParameterValue') {
+      return '';
+    }
+    return 'Error: ${err.Message[0]}';
+  } catch (ex) {}
+  return JSON.stringify(error);
 };
 
 const generateResponse = function (results) {
@@ -43,7 +47,7 @@ const generateResponse = function (results) {
 };
 
 module.exports.url = function (url, reply) {
-  if (amazonClient === null) return log.error('Unable to handle amazon url; lib not loaded');
+  if (amazonClient === null) return;
   const asin = extractAsin(url);
   if (asin) {
     const query = { itemId: asin };

--- a/modules/amazon/index.js
+++ b/modules/amazon/index.js
@@ -3,10 +3,13 @@ const amazon = require('amazon-product-api');
 let amazonClient = null;
 let log;
 
-module.exports.init = function (bot) {
+module.exports.init = function init(bot) {
   log = bot.log;
   bot.getConfig('amazon.json', (err, conf) => {
-    if (err) return log.error(`Unable to load amazon module: ${err}`);
+    if (err) {
+      log.error(`Unable to load amazon module: ${err}`);
+      return;
+    }
     try {
       amazonClient = amazon.createClient(conf);
     } catch (ex) {
@@ -15,38 +18,42 @@ module.exports.init = function (bot) {
   });
 };
 
-const extractAsin = function (url) {
+function extractAsin(url) {
   let asin;
   const amazonRegex = /(B[0-9]{2}[0-9A-Z]{7}|[0-9]{9}(?:X|[0-9]))/;
-  match = amazonRegex.exec(url);
+  const match = amazonRegex.exec(url);
   if (match && match[1]) { asin = match[0]; }
   return asin;
-};
+}
 
-const generateErrorMessage = function (error) {
+function generateErrorMessage(error) {
   try {
     const err = error[0].Error[0];
-    // AWS.InvalidParameterValue is returned when an prospective ASIN isn't actually a real ASIN, so we squash it
-    if (err.Code[0] == 'AWS.InvalidParameterValue') {
+    // AWS.InvalidParameterValue is returned when an prospective ASIN isn't
+    // actually a real ASIN, so we squash it
+    if (err.Code[0] === 'AWS.InvalidParameterValue') {
       return '';
     }
-    return 'Error: ${err.Message[0]}';
-  } catch (ex) {}
+    return `Error: ${err.Message[0]}`;
+  } catch (ex) {
+    // ignore error for json-stringifying
+  }
   return JSON.stringify(error);
-};
+}
 
-const generateResponse = function (results) {
+function generateResponse(results) {
   const attributes = results[0].ItemAttributes[0];
   let msg = attributes.Title;
-  // Free Prime exclusives and sold out items do not have a price. If this occurs, simply return title
+  // Free Prime exclusives and sold out items do not have a price. If this
+  // occurs, simply return title
   if (typeof attributes.ListPrice !== 'undefined') {
     const price = attributes.ListPrice[0].FormattedPrice[0];
     msg += `- [${price}]`;
   }
   return msg;
-};
+}
 
-module.exports.url = function (url, reply) {
+module.exports.url = function onurl(url, reply) {
   if (amazonClient === null) return;
   const asin = extractAsin(url);
   if (asin) {
@@ -58,7 +65,9 @@ module.exports.url = function (url, reply) {
       } else {
         msg = generateResponse(results);
       }
-      if (msg) return reply(msg);
+      if (msg) {
+        reply(msg);
+      }
     });
   }
 };

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "node --max_old_space_size=350 index.js",
     "install": "./installModules.sh",
     "test": "mocha $(git ls-files | grep -E 'test.js$')",
-    "lint": "eslint $(git ls-files | grep -E '\\.js$' | grep -E '^(bot.js|index.js|modules/bully.js|modules/featurerequest.js|modules/mastodon|modules/schedule|modules/nickserv.js|modules/test2.js)')"
+    "lint": "eslint $(git ls-files | grep -E '\\.js$' | grep -E '^(bot.js|index.js|modules/bully.js|modules/featurerequest.js|modules/mastodon|modules/schedule|modules/nickserv.js|modules/test2.js|modules/amazon/)')"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Gotta catch em all.

If there was an issue with the credentials supplied, before the module
would crash due to `error[0].Error[0]`.

This ensures that will not crash the whole bot.

This also drops the 'new' keyword per upstream's documentation and
reduces logging verbosity a bit.

cc @gmackie 