### PR TITLE
Made nickserv less async (fixes #95, part of #144).

### DIFF
--- a/conf/nickserv.example.json
+++ b/conf/nickserv.example.json
@@ -1,3 +1,5 @@
 {
-	"password" : "dicks"
+  "nickserv": "nickserv",
+  "password" : "dicks",
+  "successtext": "^You are now identified for "
 }


### PR DESCRIPTION
Nickserv was previously async enough to identify after all channels were joined. I've now configured the module to retry joining channels if Nickserv sends us a notice with specific text (you are now identified). This isn't quite the workaround described in #95, but it works!

Also added logging in a few spots and removed tabs.

edit: cc #144 