### PR TITLE
:snake: Allow non-camelcase function names

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "rules": {
         "global-require": "off",
         "import/no-dynamic-require": "off",
-        "prefer-destructuring": "off"
+        "prefer-destructuring": "off",
+        "camelcase": "off"
     }
 }


### PR DESCRIPTION
A bunch of euircbot's code uses :snake: case, and frankly I prefer it myself.