### PR TITLE
Add URL matching to Wikipedia module

### DIFF
--- a/modules/wikipedia/index.js
+++ b/modules/wikipedia/index.js
@@ -2,21 +2,37 @@ const wiki = require('wikijs').default;
 
 module.exports.commands = ['wiki', 'wikipedia'];
 
-function prettyPage(page) {
+const urlRegex = /^(?:https?:\/\/)?(?:en\.)?wikipedia\.org\/wiki\/(.+)/;
+
+const errorMessage = term => `No Wikipedia page found for "${term}"`;
+
+function shortSummary(page, withUrl) {
   return page.summary()
     // Get the first "sentence" (hopefully)
     .then(str => str.substr(0, str.indexOf('.') + 1))
     // Truncate with an ellipsis if length exceeds 250 chars
     .then(str => (str.length > 250 ? `${str.substr(0, 250)}...` : str))
-    // Append Wikipedia URL
-    .then(str => `${str} <${page.raw.canonicalurl}>`);
+    // Append URL if requested
+    .then(str => (withUrl ? `${str} <${page.raw.canonicalurl}>` : str));
 }
 
-module.exports.run = function run(remainder, parts, reply) {
+module.exports.run = (remainder, parts, reply) => {
   wiki().search(remainder, 1)
     .then(data => data.results[0])
     .then(wiki().page)
-    .then(prettyPage)
+    .then(page => shortSummary(page, true))
     .then(reply)
-    .catch(() => reply(`No Wikipedia page found for "${remainder}"`));
+    .catch(() => reply(errorMessage(remainder)));
+};
+
+module.exports.url = (url, reply) => {
+  if (urlRegex.test(url)) {
+    const [, match] = urlRegex.exec(url);
+    const title = decodeURIComponent(match);
+
+    wiki().page(title)
+      .then(shortSummary)
+      .then(reply)
+      .catch(() => reply(errorMessage(title)));
+  }
 };


### PR DESCRIPTION
Example:

```
│@natalie | https://en.wikipedia.org/wiki/Papier-m%C3%A2ch%C3%A9   │
│     bot | Papier-mâché (UK: , US: ; French: [papje mɑʃe],        │
│         | literally "chewed paper") is a composite material      │
│         | consisting of paper pieces or pulp, sometimes          │
│         | reinforced with textiles, bound with an adhesive, such │
│         | as glue, starch, or wallpaper paste.                   │
│@natalie | http://wikipedia.org/wiki/Bluefaced_Leicester          │
│     bot | The Bluefaced Leicester (BFL) is a longwool breed of   │
│         | sheep which evolved from a breeding scheme of Robert   │
│         | Bakewell, in Dishley, Leicestershire in the eighteenth │
│         | century.                                               │
│@natalie | https://en.wikipedia.org/wiki/fjfjfjfjfjfjfjfjfjfj     │
│     bot | No Wikipedia page found for "fjfjfjfjfjfjfjfjfjfj"     │
```