### PR TITLE
modules/title: only pick the first title

### DIFF
--- a/modules/title/index.js
+++ b/modules/title/index.js
@@ -21,8 +21,7 @@ function getSelector(url, selector, reply) {
     }
 
     const res = cheerio(selector, html);
-    console.log(res);
-    reply(res.text().trim());
+    reply(res.first().text().trim());
   });
 }
 


### PR DESCRIPTION
Some pages have multiple title tags. Such as in iframes. That is not
something we want.

Especially since those titles may be from ads like 'Share on facebook'
and spam the channel like mad. Looking at you buzzfeed.