### PR TITLE
modules/wolf: print query interpretation

### DIFF
--- a/modules/wolf/index.js
+++ b/modules/wolf/index.js
@@ -49,6 +49,8 @@ module.exports.run = function (remainder, parts, reply) {
       return;
     }
 
+    const interp = subpodValue(res[0].subpods[0]);
+
     const r = function (...args) {
       reply.custom({ lines: 5, pmExtra: true, replaceNewlines: true }, ...args);
     };
@@ -56,7 +58,7 @@ module.exports.run = function (remainder, parts, reply) {
     const primary_pods = res.filter(x => x.primary);
     if (primary_pods.length === 0) {
       try {
-        r(`${res[0].subpods[0].text}: ${res[1].subpods[0].text}`);
+        r(`${interp}: ${res[1].subpods[0].text}`);
         return;
       } catch (ex) {
         r(`No primary pod, try http://www.wolframalpha.com/input/?i=${encodeURIComponent(remainder)}`);
@@ -70,11 +72,16 @@ module.exports.run = function (remainder, parts, reply) {
       r('Not sure how to handle primary pod, someone should pull request this');
       return;
     }
-    let title = '';
-    if (ppod.title !== 'Result') {
-      title = ppod.title;
+    const titleParts = [];
+    if (interp !== remainder) {
+      titleParts.push(interp);
+    }
+    if (ppod.title !== 'Result' && ppod.title !== 'Response') {
+      titleParts.push(ppod.title);
     }
     const subval = subpodValue(ppod.subpods[0]);
+
+    const title = titleParts.join(': ');
 
     if (title && subval) {
       r(`${title}: ${subval}`);


### PR DESCRIPTION
There are many query responses that make very litle sense without the
interpretation.

This change attempts to print the query interpretation (always available
in the first pod afaik) in any case where it doesn't exactly match the
user's input.

Example query this improves:

```
<user> !wolf yo
<bot> Suspended pentatonic scale built on C_4: Notes: C_4 | D_4 | F_4 | G_4 | Bflat_4
```

whereas before, it would have just had `Notes: ....`