### PR TITLE
bot: fix flags in fs storage

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -485,7 +485,7 @@ bot.fsStoreData = function botFsStoreData(namespace, filePath, data, flag, cb) {
 
   bot.createPathIfNeeded(finalPath, (err) => {
     if (err) return writeCb(err);
-    return fs.writeFile(finalPath, data, { writeFlag }, writeCb);
+    return fs.writeFile(finalPath, data, { flag: writeFlag }, writeCb);
   });
 };
 


### PR DESCRIPTION
This bug was inadvertently introduced when the parameter was renamed
from 'flag' to 'writeFlag' as part of eslint refactoring.

This fixes the erroneous change.

The "appendDataFile" function exposed to modules was impacted by this,
and as a result each call to "append" really replaced the contents of
the file.