### PR TITLE
[mastodon] Accept more ActivityPub actor types

### DIFF
--- a/modules/mastodon/index.js
+++ b/modules/mastodon/index.js
@@ -154,8 +154,8 @@ function fetchResource(url, fn) {
     } else {
       try {
         const record = JSON.parse(body);
-        if (!['Note', 'Person'].includes(record.type)) {
-          fn(new Error('record is not a Note or Person'));
+        if (!['Note', 'Application', 'Group', 'Organization', 'Person', 'Service'].includes(record.type)) {
+          fn(new Error('record is not of a known type'));
         } else {
           fn(null, record);
         }
@@ -189,7 +189,7 @@ function formatRecord(record, fn) {
       }
       fn(str);
     });
-  } else if (record.type === 'Person') {
+  } else {
     fn(`${record.name} (@${record.preferredUsername}): ${htmlToText(record.summary)}`);
   }
 }


### PR DESCRIPTION
This enables posting URLs to bot users, which are the `Service` actor type.

These are all the actor types permitted in Mastodon's code base.