### PR TITLE
Fix for Dockerfile smell DL3059

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM node:14
 COPY . /usr/src/app/
 WORKDIR /usr/src/app
 
-RUN useradd --home-dir /usr/src/app bot
-RUN chown -R bot:bot /usr/src/app
+RUN useradd --home-dir /usr/src/app bot \
+    && chown -R bot:bot /usr/src/app
 VOLUME /usr/src/app/conf
 VOLUME /usr/src/app/data
 


### PR DESCRIPTION
Hi!
The Dockerfile placed at "Dockerfile" contains the best practice violation [DL3059](https://github.com/hadolint/hadolint/wiki/DL3059) detected by the [hadolint](https://github.com/hadolint/hadolint) tool.

The smell DL3059 occurs if there are multiple consecutive RUN instructions. Each RUN will correspond to a layer of the final Docker image, thus is recommended to compact them to reduce the number of layers for the final image.
This pull request proposes a fix for that smell generated by my fixing tool. The patch was manually verified before opening the pull request. To fix this smell, specifically, The consecutive RUN instructions have been chained until a comment or a different instruction appears.

This change is only aimed at fixing that specific smell. If the fix is not valid or useful, please briefly indicate the reason and suggestions for possible improvements.

Thanks in advance
